### PR TITLE
Add example for submitSuccess.ufForm

### DIFF
--- a/pages/13.client-side-code/04.components/01.forms/docs.md
+++ b/pages/13.client-side-code/04.components/01.forms/docs.md
@@ -150,6 +150,21 @@ Defaults to `0`.
 ### submitSuccess.ufForm
 
 Triggered when the form has been submitted successfully.  This happens after the submission button has been re-enabled.
+Any response from the server in JSON format will be provided in the `data` parameter.
+For example, log the response from the server to console and close the modal:
+```
+$("body").on('renderSuccess.ufModal', function (data) {
+    var modal = $(this).ufModal('getModal');
+    var form = modal.find('.js-form');
+
+    form.ufForm()
+    .on("submitSuccess.ufForm", function(event, data, textStatus, jqXHR) {
+        console.log(data)
+        $("body").ufModal('destroy');
+        $('.modal-backdrop').remove();
+    });
+});
+```
 
 ### submitError.ufForm
 

--- a/pages/13.client-side-code/04.components/01.forms/docs.md
+++ b/pages/13.client-side-code/04.components/01.forms/docs.md
@@ -149,20 +149,17 @@ Defaults to `0`.
 
 ### submitSuccess.ufForm
 
-Triggered when the form has been submitted successfully.  This happens after the submission button has been re-enabled.
-Any response from the server in JSON format will be provided in the `data` parameter.
-For example, log the response from the server to console and close the modal:
-```
-$("body").on('renderSuccess.ufModal', function (data) {
-    var modal = $(this).ufModal('getModal');
-    var form = modal.find('.js-form');
+Triggered when the form has been submitted successfully. This happens after the submission button has been re-enabled.
 
-    form.ufForm()
-    .on("submitSuccess.ufForm", function(event, data, textStatus, jqXHR) {
-        console.log(data)
-        $("body").ufModal('destroy');
-        $('.modal-backdrop').remove();
-    });
+Any response from the server will be provided in the `data` parameter as JSON. For example, to log the response from the server when the form has been submitted successfully :
+
+```
+$("#account-settings").ufForm({
+    validator: page.validators.account_settings,
+    msgTarget: $("#alerts-page")
+}).on("submitSuccess.ufForm", function(event, data, textStatus, jqXHR) {
+    // Log data to console
+    console.log(data)
 });
 ```
 


### PR DESCRIPTION
It's unclear what the parameters for submitSuccess.ufForm are without digging through the source to find an example; so a simple demonstration showing how to log the server response data to console.