### PR TITLE
Add clarification to docs to show when bower.json was deprecated

### DIFF
--- a/pages/05.sprinkles/02.contents/docs.md
+++ b/pages/05.sprinkles/02.contents/docs.md
@@ -56,7 +56,7 @@ To download frontend dependencies, from the project root directory:
 $ php bakery build-assets
 ```
 
->>>> Bower support is now deprecated. `/package.json` should be used instead.
+>>>> Bower support is deprecated since version 4.2.0. `/package.json` should be used instead.
 
 ### /asset-bundles.json
 


### PR DESCRIPTION
Clarify that bower.json was deprecated in 4.2.0 instead of 'now deprecated'.