### PR TITLE
Added `path_for` mention and usage example

### DIFF
--- a/pages/03.installation/01.environment/01.homestead/docs.md
+++ b/pages/03.installation/01.environment/01.homestead/docs.md
@@ -79,6 +79,11 @@ cd userfrosting
 git clone -b v7.20.0 https://github.com/laravel/homestead.git vagrant/Homestead
 ```
 
+You will need a SSH key-pair to connect to the Virtual Machine created in the next step. 
+```sh
+ssh-keygen -t rsa -f $HOME/.ssh/homestead_rsa
+```
+
 Now simply run `vagrant up` from the root of your cloned fork of the UserFrosting Git repository :
 
 ```sh

--- a/pages/03.installation/01.environment/01.homestead/docs.md
+++ b/pages/03.installation/01.environment/01.homestead/docs.md
@@ -79,10 +79,15 @@ cd userfrosting
 git clone -b v7.20.0 https://github.com/laravel/homestead.git vagrant/Homestead
 ```
 
-You will need a SSH key-pair to connect to the Virtual Machine created in the next step. 
+You will need a SSH key-pair to connect to the Virtual Machine created in the next step. If you already have a keypair in your user's home directory you can skip this step. Otherwise you can generate a new SSH keypair using the `ssh-keygen` tool.  Before doing this, make sure you have a `.ssh` directory in your user's home directory (e.g. `C:/Users/<username>` in Windows, or `/Users/<username>` in Mac/Linux).  If not, you can do `mkdir $HOME/.ssh`.
+
+Then, run the following command:
+
 ```sh
-ssh-keygen -t rsa -f $HOME/.ssh/homestead_rsa
+ssh-keygen -t rsa -f $HOME/.ssh/id_rsa
 ```
+
+It will prompt you to create a passphrase. Since this is all for a development environment, we don't need a passphrase - just hit Enter.
 
 Now simply run `vagrant up` from the root of your cloned fork of the UserFrosting Git repository :
 

--- a/pages/04.troubleshooting/03.common-problems/docs.md
+++ b/pages/04.troubleshooting/03.common-problems/docs.md
@@ -16,7 +16,7 @@ If installation of npm dependencies fails, see [npm](/basics/requirements/essent
 
 ### When trying to view my site I get an error like "An exception has been thrown during the rendering of a template ("The asset 'vendor/font-awesome/css/font-awesome.css' could not be found. Referenced in '/home/vagrant/userfrosting/app/sprinkles/core/asset-bundles.json [css/main]'.")."
 
-An installation step was missed or failed. Try running `php bakery bake` and check for any error messages.
+This is an indication that asset build failed or you missed a step in the installation process. Try running `php bakery bake` and check for any error messages.
 
 ### Installation went fine, except I don't see any styling on my home page.  I am using Apache.
 

--- a/pages/04.troubleshooting/03.common-problems/docs.md
+++ b/pages/04.troubleshooting/03.common-problems/docs.md
@@ -14,6 +14,10 @@ taxonomy:
 
 If installation of npm dependencies fails, see [npm](/basics/requirements/essential-tools-for-php#npm) to ensure npm is correctly installed and updated. You may need to [change npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions).
 
+### When trying to view my site I get an error like "An exception has been thrown during the rendering of a template ("The asset 'vendor/font-awesome/css/font-awesome.css' could not be found. Referenced in '/home/vagrant/userfrosting/app/sprinkles/core/asset-bundles.json [css/main]'.")."
+
+An installation step was missed or failed. Try running `php bakery bake` and check for any error messages.
+
 ### Installation went fine, except I don't see any styling on my home page.  I am using Apache.
 
 UserFrosting uses a [dynamic routing system](/asset-management/basic-usage#PublicassetURLs) for serving assets in a development environment.  For this to work on an Apache webserver, `mod_rewrite` needs to be enabled, **and** you need to give Apache permission to use the `.htaccess` file in `public/`.

--- a/pages/04.troubleshooting/03.common-problems/docs.md
+++ b/pages/04.troubleshooting/03.common-problems/docs.md
@@ -16,7 +16,7 @@ If installation of npm dependencies fails, see [npm](/basics/requirements/essent
 
 ### When trying to view my site I get an error like "An exception has been thrown during the rendering of a template ("The asset 'vendor/font-awesome/css/font-awesome.css' could not be found. Referenced in '/home/vagrant/userfrosting/app/sprinkles/core/asset-bundles.json [css/main]'.")."
 
-This is an indication that asset build failed or you missed a step in the installation process. Try running `php bakery bake` and check for any error messages.
+This is an indication that asset build failed or you missed a step in the installation process. Try [running the installer](/installation/environment/native#run-the-installer) again with`php bakery bake` and check for any error messages. 
 
 ### Installation went fine, except I don't see any styling on my home page.  I am using Apache.
 

--- a/pages/10.templating-with-twig/03.filters-and-functions/docs.md
+++ b/pages/10.templating-with-twig/03.filters-and-functions/docs.md
@@ -26,4 +26,14 @@ You can perform permission checks in your Twig templates using the `checkAccess`
 {{ translate("ACCOUNT_USER_CHAR_LIMIT", {min: 4, max: 200}) }}
 ```
 
+### path_for
+
+You can use `path_for` in your Twig templates to get the URL for a named route. This Twig function is simply mapped to the Slim router `pathFor(string $name, array $data, array $queryParams)` instance method.
+
+```
+<li>
+    <a href="{{ path_for('awesome-owls' )}}">Owls</a>
+</li>
+```
+
 To contribute to this documentation, please submit a pull request to our [learn repository](https://github.com/userfrosting/learn/tree/master/pages).


### PR DESCRIPTION
I wasn't sure if UF included a Twig extension for using named routes within templates. I had to check the source code to find out.