### PR TITLE
Added /app/storage as requring write permissons

### DIFF
--- a/pages/03.installation/02.requirements/01.basic-stack/docs.md
+++ b/pages/03.installation/02.requirements/01.basic-stack/docs.md
@@ -69,6 +69,7 @@ UserFrosting needs to be able to write to the file system for a few directories:
 - `/app/cache` - This is where UF will cache rendered Twig templates for faster processing, as well as other objects;
 - `/app/logs` - UF writes error, debugging, and mail logs to this directory;
 - `/app/sessions` - If you're using file-based sessions, UF writes to this directory instead of PHP's default session directory.
+- `/app/storage`
 
 You should make sure that the group under which your webserver runs (for example, `www-data`, `apache`, `_www`, `nobody`) has read and write permissions for these directories. You may need to use `chgrp` to ensure that these directories are owned by the webserver's group.
 


### PR DESCRIPTION
I have simply added /app/storage to the list of directories that require write permission.

I raised an issue here https://github.com/userfrosting/learn/issues/111 about inconsistencies in the documentation around /app/storage and then response here https://github.com/userfrosting/learn/issues/111#issuecomment-1133744853 was that /app/storage does indeed require write permissions be granted.