### PR TITLE
Add some stuff to the v4 -> v5.0 upgrade guide, Fix typos

### DIFF
--- a/pages/07.dependency-injection/04.adding-services/docs.md
+++ b/pages/07.dependency-injection/04.adding-services/docs.md
@@ -62,6 +62,21 @@ class MapBuilderService implements ServicesProviderInterface
 
 [notice=tip]You'll notice that we've added `use UserFrosting\Sprinkle\Site\GoogleMaps\MapBuilder;` to the top of the file. This means that we don't have to use the fully qualified class name (with the entire namespace) every time we want to refer to the `MapBuilder` class.[/notice]
 
+If you need to pull in another service, for example the config to retrieve an API key, you can add them as the parameter, and the dependency injector will automatically pick it up.
+
+```php
+...
+MapBuilder::class => function (Config $config) {
+    $apiKey = $config['api.key'];
+
+    // Now, actually build the object
+    $mapBuilder = new MapBuilder($apiKey);
+
+    return $mapBuilder;
+},
+...
+```
+
 ### Register your service
 
 The next step is to tell UserFrosting to load your service in your [Sprinkle Recipe](/sprinkles/recipe#getservices). To do so, you only need to list all the service providers you want to automatically register inside the `$getServices` property of your sprinkle class :

--- a/pages/08.routes-and-controllers/04.controller-classes/docs.md
+++ b/pages/08.routes-and-controllers/04.controller-classes/docs.md
@@ -22,6 +22,9 @@ namespace UserFrosting\Sprinkle\Site\Controller;
 
 use UserFrosting\Sprinkle\Site\Model\Owl;
 
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
 class OwlController
 {
     public function getOwls(string $genus, Request $request, Response $response): Response
@@ -74,6 +77,9 @@ namespace UserFrosting\Sprinkle\Site\Controller;
 use UserFrosting\Sprinkle\Site\Model\Owl;
 use UserFrosting\Sprinkle\Site\Finder\VoleFinder;
 
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
 class OwlController
 {
     public function getOwls(string $genus, Request $request, Response $response, VoleFinder $voleFinder): Response
@@ -96,6 +102,9 @@ namespace UserFrosting\Sprinkle\Site\Controller;
 
 use UserFrosting\Sprinkle\Site\Model\Owl;
 use UserFrosting\Sprinkle\Site\Finder\VoleFinder;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
 
 class OwlController
 {
@@ -147,6 +156,9 @@ namespace UserFrosting\Sprinkle\Site\Controller;
 
 use UserFrosting\Sprinkle\Site\Model\Owl;
 use UserFrosting\Sprinkle\Site\Finder\VoleFinder;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
 
 class GetOwlsAction
 {

--- a/pages/14.database/04.seeding/docs.md
+++ b/pages/14.database/04.seeding/docs.md
@@ -42,7 +42,7 @@ class MySeed implements SeedInterface
 
 ## Registering Seeds
 
-To be picked up by the `seed` bakery command, a seed class files must first be registered in the the *Sprinkle Recipe*, using the `SeedRecipe` sub-recipe and the `getSeeds():array` method: 
+To be picked up by the `seed` bakery command, a seed class files must first be registered in the *Sprinkle Recipe*, using the `SeedRecipe` sub-recipe and the `getSeeds():array` method: 
 
 ```php
 <?php

--- a/pages/22.upgrading/01.46-to-50/02.guide/docs.md
+++ b/pages/22.upgrading/01.46-to-50/02.guide/docs.md
@@ -195,7 +195,7 @@ The classmapper has been removed in UF5. PHP-DI should be used instead, via the 
 
 Migrations are mostly the same, only the class structure as changed, as well as the need to register migration in your Sprinkle Recipe. The key points regarding migration are as follow: 
 
-1. Up/Down return type : The `up()` and `down()` method [must now return `void`](/database/migrations#base-class)
+1. Up/Down return type : The `up()` and `down()` method [must now have a return type of `void`](/database/migrations#base-class)
    
 2. Migrations must [now extend](/database/migrations#base-class) `UserFrosting\Sprinkle\Core\Database\Migration`. Change `use UserFrosting\System\Bakery\Migration;` to `use UserFrosting\Sprinkle\Core\Database\Migration;` in every one of your migrations.
    

--- a/pages/22.upgrading/01.46-to-50/02.guide/docs.md
+++ b/pages/22.upgrading/01.46-to-50/02.guide/docs.md
@@ -215,16 +215,16 @@ The only change in database model is the `$timestamps` property is not `true` by
 
 ### Routes
 
-The way to register route as changed. The definition is mostly the same, however the routes are now a real PHP classes, instead of static php resources. Check out the [Registering routes](/routes-and-controllers/registering-routes) guide for more information.
+The way to register routes has changed. The definition is mostly the same, however the routes are now real PHP classes, instead of static php resources. Check out the [Registering routes](/routes-and-controllers/registering-routes) guide for more information.
 
-To updated your routes, you should start by :
+To updated your routes, you should start by:
 
 1. Move your routes from `app/routes/*` to `app/src/Routes/*`;
 2. Update your routes definitions so it's a class [implementing RouteDefinitionInterface](/routes-and-controllers/registering-routes)
 3. Register your routes in your Sprinkle Recipe.
 
-A few other key point to know:
-1. Route groups definition has changed. See [Slim Documentation](https://www.slimframework.com/docs/v4/objects/routing.html#route-groups) for more information
+A few other key points to know:
+1. Definitions for route groups has changed. See [Slim Documentation](https://www.slimframework.com/docs/v4/objects/routing.html#route-groups) for more information
 2. Controller resolution should be updated to make use of [PHP’s `::class` operator](https://www.slimframework.com/docs/v4/objects/routing.html#container-resolution)
 3. Middleware must now be called by their class name. For example, `authGuard` must be updated to `UserFrosting\Sprinkle\Account\Authenticate\AuthGuard::class`
 
@@ -266,21 +266,21 @@ This also mean the **Classmapper** is not available anymore in sprunjes. You sho
 
 ### Controllers
 
-Simple changes have been made to controller classes : 
+Simple changes have been made to controller classes: 
 
 1. Remove `extends SimpleController`, no extension is required anymore.
 2. `use Slim\Http\Request;` must be changed to `use Psr\Http\Message\ServerRequestInterface as Request;`
 3. `use Slim\Http\Response;` must be changed to `use Psr\Http\Message\ResponseInterface as Response;`
-4. Since the DI container is not available globally in controllers, the services you requires must be [injected in constructor](/routes-and-controllers/controller-classes#service-injection)
+4. Since the DI container is not available globally in the controllers, the services you require must be [injected via the constructor](/routes-and-controllers/controller-classes#service-injection)
    1. For example, to use the `view` service, inject `Slim\Views\Twig;` 
 
 See [Controller classes](/routes-and-controllers/controller-classes) guide for more information.
 
-[note]If your sprinkle extends a controller class from a default sprinkle instead of `SimpleController`, note that **every** controller classes from default sprinkles have been moved, renamed and rewritten as *Action classes*. Make sure to check out the sprinkle source code to find out how to update your sprinkle.[/note]
+[note]If your sprinkle extends a controller class from a default sprinkle instead of `SimpleController`, note that **every** controller class from the default sprinkles have been moved, renamed and rewritten as *Action classes*. You will need to check out the sprinkle source code to find out how to update your sprinkle.[/note]
 
 ### Bakery
 
-Simple changes have been made to bakery commands : 
+Simple changes have been made to bakery commands: 
 
 1. Command must extend `Symfony\Component\Console\Command\Command` instead of `UserFrosting\System\Bakery\BaseCommand`
 2. Service should be injected through the class constructor (don't forget to call the parent constructor) or via [attribute injection](https://php-di.org/doc/attributes.html#inject).
@@ -293,7 +293,7 @@ Also note that the `create-admin` command has been renamed `create:admin-user`. 
 
 ### Resources Stream / Locator
 
-Not must as changed regarding the Resource Locator. Refer to the [Locator Service](/advanced/locator) page for more information. Note however that the two stream below have been renamed:
+Not must has changed regarding the Resource Locator. Refer to the [Locator Service](/advanced/locator) page for more information. Note however that the two streams below have been renamed:
 
 1. log -> logs
 2. session -> sessions

--- a/pages/22.upgrading/01.46-to-50/02.guide/docs.md
+++ b/pages/22.upgrading/01.46-to-50/02.guide/docs.md
@@ -203,6 +203,12 @@ Migrations are mostly the same, only the class structure as changed, as well as 
    
 4. Migrations are not auto-discovered anymore. You need to add them to your sprinkle recipe, using `MigrationRecipe`. See [the migration chapter](/database/migrations#sprinkle-recipe) for more information and a detailed guide.
 
+### Seeds
+
+Seeds are also mostly the same, they just need to implement `\UserFrosting\Sprinkle\Core\Seeder\SeedInterface`, and have a `run()` function with a return type of `void`. They are also not auto-discovered, so need to be added to your sprinkle recipe using `SeedRecipe`. 
+
+See [the seeding chapter](/database/seeding) for more details.
+
 ### Models
 
 The only change in database model is the `$timestamps` property is not `true` by default. It used to be `false`. ` public $timestamps = true;` can be removed from your models, unless you're **not** using timestamps where you should add `public $timestamps = false;`.

--- a/pages/22.upgrading/01.46-to-50/02.guide/docs.md
+++ b/pages/22.upgrading/01.46-to-50/02.guide/docs.md
@@ -197,7 +197,7 @@ Migration are mostly the same, only the class structure as changed, as well as t
 
 1. Up/Down return type : The `up()` and `down()` method [must now return `void`](/database/migrations#base-class)
    
-2. Migration must [now implement](/database/migrations#base-class) `UserFrosting\Sprinkle\Core\Database\Migration`. Change `use UserFrosting\System\Bakery\Migration;` to `use UserFrosting\Sprinkle\Core\Database\Migration;` in every one of your migrations.
+2. Migration must [now extend](/database/migrations#base-class) `UserFrosting\Sprinkle\Core\Database\Migration`. Change `use UserFrosting\System\Bakery\Migration;` to `use UserFrosting\Sprinkle\Core\Database\Migration;` in every one of your migrations.
    
 3. [Dependencies](/database/migrations#dependencies) must now be declared in a static property. Change `public $dependencies = [];` to `public static $dependencies = [];` in every one of your migrations.
    

--- a/pages/22.upgrading/01.46-to-50/02.guide/docs.md
+++ b/pages/22.upgrading/01.46-to-50/02.guide/docs.md
@@ -6,33 +6,33 @@ taxonomy:
     category: docs
 ---
 
-Upgrading an existing sprinkle from UserFrosting 4 to UserFrosting 5 can unfortunately be a difficult task. It all depends of how must customization of the core code you have done. Very basic sites will be easy to upgrade, very complex one could be a nightmare. However, it's for the greater good. UserFrosting 5 is more modern and uses new techniques 
+Upgrading an existing sprinkle from UserFrosting 4 to UserFrosting 5 can unfortunately be a difficult task. It all depends of how much customization of the core code you have done. Very basic sites will be easy to upgrade, very complex one could be a nightmare. However, it's for the greater good; UserFrosting 5 is more modern and uses new techniques. 
 
-[notice=warning]This guide contains the most important changes and action you need to take to upgrade your UserFrosting 4 Sprinkle. However, **it's far from complete**, as there are too many changes to document. Make sure you have a backup of your existing application and your **development database** before starting. 
+[notice=warning]This guide contains the most important changes and the actions you need to take to upgrade your UserFrosting 4 Sprinkle. However, **it's far from complete**, as there are too many changes to document. Make sure you have a backup of your existing application and your **development database** before starting. 
 
 If you spot anything missing, don't hesitate to contribute to this page via the [*edit this page*](https://github.com/userfrosting/learn/blob/5.1/pages/22.upgrading/01.46-to-50/02.guide/docs.md) button at the top.[/notice]
 
 ## Before you start
 
-The upgrade path for your UserFrosting 4 sprinkle will depend on how many features you're using. The good new is, the database structure is the same, and the frontend is 90% the same. 
+The upgrade path for your UserFrosting 4 sprinkle will depend on how many features you're using. The good news is, the database structure is the same, and the frontend is 90% the same. 
 
-To begin the upgrade journey, **the first you should do is a [fresh install](/installation) of UserFrosting 5**. This is important, as it will allow you to familiarize yourself with the new structure, as well as validate that your [local development environment](/background/develop-locally-serve-globally) is up to date and meet the [minimum requirements](/installation/requirements).
+To begin the upgrade journey, **the first you should do is a [fresh install](/installation) of UserFrosting 5**. This is important, as it will allow you to familiarize yourself with the new structure, as well as validate that your [local development environment](/background/develop-locally-serve-globally) is up to date and meets the [minimum requirements](/installation/requirements).
 
-Once you have a functioning vanilla version of UserFrosting 5, you can begin upgrading your sprinkle.
+Once you have a functioning vanilla version of UserFrosting 5, you can begin to upgrade your sprinkle.
 
 [notice]While the database structure is mostly the same between V4 and V5, it is highly recommended you keep a backup of your existing application and your **development database**.[/notice]
 
 ## Upgrading your sprinkle structure
 
-As seen on the [previous page](/upgrading/46-to-50/changelog), one of the biggest change is the app structure. It's recommended before you start to head over to [Chapter 3 - App Structure](/structure), to learn more about this new structure. 
+As seen on the [previous page](/upgrading/46-to-50/changelog), one of the biggest changes is the app structure. It's recommended before you start to head over to [Chapter 3 - App Structure](/structure), to learn more about this new structure. 
 
-Once you're familiar with the new structure, it's time to move thing around so your sprinkle meet the new structure. There's two options here : You can either start from scratch from the [Skeleton repo](/structure/introduction#the-app-skeleton-your-project-s-template), *or* you can manually upgrade in place.
+Once you're familiar with the new structure, it's time to move thing around so your sprinkle meets the new structure. There's two options here: You can either start from scratch from the [Skeleton repo](/structure/introduction#the-app-skeleton-your-project-s-template), *or* you can manually upgrade in place.
 
 The first option is easier as the base has been setup for you, and you can start right away moving your code into the skeleton created from the sprinkle template, in a new git repository. However, it's drawback is you'll probably lose your Git History. The second option is harder, but since you're starting from your existing code, you'll keep your git history if your code is saved on Github for example.
 
 ### Option 1 - Start over from the Skeleton
 
-To start with this option, the first step is to create a [fresh install](/installation) from the app skeleton. You'll then have an empty sprinkle with the new structure, ready to copy your code into it. However there's some step you need to follow before going further.
+To start with this option, the first step is to create a [fresh install](/installation) from the app skeleton. You'll then have an empty sprinkle with the new structure, ready to copy your code into it. However there's some steps you need to follow before going further.
 
 #### Update `composer.json`
 
@@ -46,7 +46,7 @@ Once this is done, you can run `composer update` to fetch dependencies.
 
 #### Edit the Recipe
 
-Next up you should familiarize yourself with the [Sprinkle Recipe](/sprinkles/recipe#name). Right now, the only thing you must update is the sprinkle name, but we'll come back later to the recipe.
+Next up, you should familiarize yourself with the [Sprinkle Recipe](/sprinkles/recipe#name). Right now, the only thing you must update is the sprinkle name, but we'll come back later to the recipe.
 
 #### Moving your code
 
@@ -56,7 +56,7 @@ At this point you can skip to [Upgrading components](/upgrading/46-to-50/guide#u
 
 ### Option 2 - Upgrade in place
 
-To start with this option, you should already be familiar with UserFrosting 5 directory structure, as it involves moving some directory around and editing some files. It also assume your code (your sprinkle) was located (and not as a community Sprinkle for example) You should have UserFrosting 5 Skeleton repo on hand to copy some files.
+To start with this option, you should already be familiar with UserFrosting 5 directory structure, as it involves moving some directories around and editing some files. It also assumes your code (your sprinkle) was located (and not as a community sprinkle for example) You should have a UserFrosting 5 skeleton repo on hand to copy some files.
 
 #### Moving files and directory
 
@@ -113,13 +113,13 @@ We'll update the rest of your recipe later.
 
 #### The entry files
 
-Finally, you'll need to update both *entry files*, aka `/bakery` and `/public/index.php`, with the correct reference to your recipe. Open both files, and replace `UserFrosting\App\MyApp` and `MyApp` with the correct reference to your recipe. See [this page](/sprinkles/customize#the-entry-files) for more information and example.
+Finally, you'll need to update both *entry files*, aka `/bakery` and `/public/index.php`, with the correct reference to your recipe. Open both files, and replace `UserFrosting\App\MyApp` and `MyApp` with the correct reference to your recipe. See [this page](/sprinkles/customize#the-entry-files) for more information and examples.
 
 ## Upgrading components
 
-At this point your UserFrosting 5 app is _kind of ready_ to work. You simply need to upgrade every component your use. The following list might contains stuff you're not using, but you should still go through them as they contains links and tip you may need later.
+At this point your UserFrosting 5 app is _kind of ready_ to work. You simply need to upgrade every component you use. The following list might contain stuff you're not using, but you should still go through them as they contain links and tips you may need later.
 
-Remember, this guide will give you only the big picture of what changed, pointing you to other part of the guide that goes in details with all the features. 
+Remember, this guide will give you only the big picture of what changed, but it will point you to the relevant parts of the documentation where more detail can be found.
 
 ### Global changes
 
@@ -135,7 +135,7 @@ Keep this in mind, especially if you've extended built-in classes. Not only may 
 
 ### Services -> Dependency Injection
 
-Services have been updated for UserFrosting 5. While the principle is the same, the way to register service is different. Services are now served by the new dependency injection container, PHP-DI. You should head over to the [Dependency Injection Chapter](/dependency-injection) to learn more about PHP-DI integration in UserFrosting 5 before going further. 
+Services have been updated for UserFrosting 5. While the principle is the same, the way to register a service is different. Services are now served by the new dependency injection container, PHP-DI. You should head over to the [Dependency Injection Chapter](/dependency-injection) to learn more about PHP-DI integration in UserFrosting 5 before going further. 
 
 Your services definition must first be updated to implement `UserFrosting\ServicesProvider\ServicesProviderInterface`. For example:
 
@@ -167,7 +167,7 @@ class ServicesProvider implements ServicesProviderInterface
 
 You'll also need to **register your service** in your recipe. Checkout [Adding Services](/dependency-injection/adding-services) for more information.
 
-Finally, instead or injecting the whole container and retrieving your service from it, your should inject the service directly into the class using [autowiring](/dependency-injection/the-di-container#autowiring) in the class constructor or thought [route service injection](/routes-and-controllers/controller-classes#service-injection) for example.
+Finally, instead of injecting the whole container and retrieving your service from it, you should inject the service directly into the class using [autowiring](/dependency-injection/the-di-container#autowiring) in the class constructor or thought [route service injection](/routes-and-controllers/controller-classes#service-injection) for example.
 
 For example:
 

--- a/pages/22.upgrading/01.46-to-50/02.guide/docs.md
+++ b/pages/22.upgrading/01.46-to-50/02.guide/docs.md
@@ -193,15 +193,15 @@ The classmapper has been removed in UF5. PHP-DI should be used instead, via the 
 
 ### Migrations
 
-Migration are mostly the same, only the class structure as changed, as well as the need to register migration in your Sprinkle Recipe. The key points regarding migration are as follow : 
+Migrations are mostly the same, only the class structure as changed, as well as the need to register migration in your Sprinkle Recipe. The key points regarding migration are as follow: 
 
 1. Up/Down return type : The `up()` and `down()` method [must now return `void`](/database/migrations#base-class)
    
-2. Migration must [now extend](/database/migrations#base-class) `UserFrosting\Sprinkle\Core\Database\Migration`. Change `use UserFrosting\System\Bakery\Migration;` to `use UserFrosting\Sprinkle\Core\Database\Migration;` in every one of your migrations.
+2. Migrations must [now extend](/database/migrations#base-class) `UserFrosting\Sprinkle\Core\Database\Migration`. Change `use UserFrosting\System\Bakery\Migration;` to `use UserFrosting\Sprinkle\Core\Database\Migration;` in every one of your migrations.
    
 3. [Dependencies](/database/migrations#dependencies) must now be declared in a static property. Change `public $dependencies = [];` to `public static $dependencies = [];` in every one of your migrations.
    
-4. Migration are not auto-discovered anymore. You need to add them to your sprinkle recipe, using `MigrationRecipe`. See [the migration chapter](/database/migrations#sprinkle-recipe) for more information and a detailed guide.
+4. Migrations are not auto-discovered anymore. You need to add them to your sprinkle recipe, using `MigrationRecipe`. See [the migration chapter](/database/migrations#sprinkle-recipe) for more information and a detailed guide.
 
 ### Models
 

--- a/pages/22.upgrading/02.50-to-51/02.guide/docs.md
+++ b/pages/22.upgrading/02.50-to-51/02.guide/docs.md
@@ -81,13 +81,13 @@ $ php bakery bake
 
 ### Font Awesome
 
-UserFrosting 5.1 now ship with Font Awesome 6 in the AdminLTE theme. While Font Awesome 6 is backward compatible with Font Awesome 5, some icons [have been renamed](https://docs.fontawesome.com/web/setup/upgrade/whats-changed#icons-renamed-in-version-6) and you might need to manually update these in your sprinkle. 
+UserFrosting 5.1 now ships with Font Awesome 6 in the AdminLTE theme. While Font Awesome 6 is backward compatible with Font Awesome 5, some icons [have been renamed](https://docs.fontawesome.com/web/setup/upgrade/whats-changed#icons-renamed-in-version-6) and you might need to manually update these in your sprinkle. 
 
-Checkout Font Awesome guide for more information : [https://docs.fontawesome.com/web/setup/upgrade/whats-changed](https://docs.fontawesome.com/web/setup/upgrade/whats-changed)
+Checkout the Font Awesome guide for more information : [https://docs.fontawesome.com/web/setup/upgrade/whats-changed](https://docs.fontawesome.com/web/setup/upgrade/whats-changed)
 
 ### Missing default permissions
 
-Some build-in permissions [were missing from the database](https://github.com/userfrosting/UserFrosting/issues/1225) :
+Some built-in permissions [were missing from the database](https://github.com/userfrosting/UserFrosting/issues/1225) :
  - `uri_role`
  - `uri_roles`
  - `uri_permissions`
@@ -100,28 +100,28 @@ Some build-in permissions [were missing from the database](https://github.com/us
  - `view_system_info`
  - `clear_cache`
 
-To add them to the database, run `php bakery seed` and select `UserFrosting\Sprinkle\Account\Database\Seeds\DefaultPermissions`. Theses will also be added to the `site-admin` role when running the seed.
+To add them to the database, run `php bakery seed` and select `UserFrosting\Sprinkle\Account\Database\Seeds\DefaultPermissions`. These will also be added to the `site-admin` role when running the seed.
 
-[notice=warning]If your application defines custom permissions to the `site-admin` role or you customized this role, **do not run the seed** unless you want to lose any custom changes. Running the seed will revert back that role to it's default state.[/notice]
+[notice=warning]If your application defines custom permissions to the `site-admin` role or you customized this role, **do not run the seed** unless you want to lose any custom changes. Running the seed will revert back the role to it's default state.[/notice]
 
 The `site-admin` role is now on par with the root user permission by default, except for the last two permissions added, `view_system_info` & `clear_cache`. Theses can be added to the role if desired using the UI.
 
 ### `urlFor` service change
 
-When calling [`urlFor`](/templating-with-twig/filters-and-functions#urlfor) **in PHP** (not Twig) to generate a route from it's name, the service as been replaced. Find and replace the following import to upgrade: 
+When calling [`urlFor`](/templating-with-twig/filters-and-functions#urlfor) **in PHP** (not Twig) to generate a route from its name, the service has been replaced. Find and replace the following import to upgrade: 
 - Find : `use Slim\Interfaces\RouteParserInterface;`
 - Replace : `use UserFrosting\Sprinkle\Core\Util\RouteParserInterface;`
 
 ### Alerts
 
-When using the [alerts](/advanced/alert-stream) service, replace `addMessageTranslated(...);` with `addMessage(...);`. The old method is still available, but deprecated and will be removed in a future version.
+When using the [alerts](/advanced/alert-stream) service, replace `addMessageTranslated(...);` with `addMessage(...);`. The old method is still available, but it is deprecated and will be removed in a future version.
 
 ### Fortress
 
-Fortress has been complexly rewritten for UserFrosting 5.1. Most class have been kept and will continue working, but these have been marked deprecated and will be removed in future version. It is recommended to upgrade your code now to avoid issues later.
+Fortress has been completely rewritten for UserFrosting 5.1. Most classes have been kept and will continue working, but these have been marked deprecated and will be removed in future version. It is recommended to upgrade your code now to avoid issues later.
 
 #### RequestSchema
-`UserFrosting\Fortress\RequestSchema` constructor first argument now accept the schema data as an array, as well as a string representing a path to the schema json or yaml file. The argument can still be omitted to create an empty schema. This change makes `UserFrosting\Fortress\RequestSchema\RequestSchemaRepository` obsolete and and such been ***deprecated***. For example:
+The `UserFrosting\Fortress\RequestSchema` constructor's first argument now accepts the schema data as an array, as well as a string representing a path to the schema json or yaml file. The argument can still be omitted to create an empty schema. This change makes `UserFrosting\Fortress\RequestSchema\RequestSchemaRepository` obsolete and and such been ***deprecated***. For example:
 
 ```php
 // Before
@@ -243,6 +243,8 @@ $errors = $this->validator->validate($schema, $data);
 if (count($errors) !== 0) {
     $e = new ValidationException();
     $e->addErrors($errors);
+
+    throw $e;
 }
 ```
 


### PR DESCRIPTION
- Fix some typos/singular and plural 
- v4 to v5 upgrade guide
  - Add section about seeds
  - Change migrations from implements to extends
- Add use for `Request` and `Response` on controller docs
- Add notes about injecting existing services into new services
- Add missing throw in validation example code